### PR TITLE
change the management of processor for load and dump in fields, becau…

### DIFF
--- a/lupin/fields/constant.py
+++ b/lupin/fields/constant.py
@@ -15,7 +15,7 @@ class Constant(Field):
         super(Constant, self).__init__(**kwargs)
         self._value = value
 
-    def load(self, value, mapper):
+    def _load(self, value, mapper):
         """Returns fixed value
 
         Args:
@@ -27,7 +27,7 @@ class Constant(Field):
         """
         return self._value
 
-    def dump(self, value, mapper):
+    def _dump(self, value, mapper):
         """Returns fixed value
 
         Args:
@@ -41,6 +41,7 @@ class Constant(Field):
 
     def extract_attr(self, obj, mapper, key=None):
         """Returns fixed value
+           using pre_dump and post_dump
 
         Args:
             obj (object): object to get value from
@@ -50,4 +51,4 @@ class Constant(Field):
         Returns:
             object
         """
-        return self._value
+        return self.dump(self._value, mapper)

--- a/lupin/fields/date.py
+++ b/lupin/fields/date.py
@@ -17,7 +17,7 @@ class Date(Field):
         super(Date, self).__init__(**kwargs)
         self._format = format
 
-    def load(self, value, mapper):
+    def _load(self, value, mapper):
         """Loads a date python object from a JSON string
 
         Args:
@@ -32,7 +32,7 @@ class Date(Field):
 
         return datetime.strptime(value, self._format).date()
 
-    def dump(self, value, mapper):
+    def _dump(self, value, mapper):
         """Dump a date to string representation
 
         Args:

--- a/lupin/fields/datetime_field.py
+++ b/lupin/fields/datetime_field.py
@@ -17,7 +17,7 @@ class DateTime(Field):
         super(DateTime, self).__init__(*args, **kwargs)
         self._format = format
 
-    def load(self, value, mapper):
+    def _load(self, value, mapper):
         """Loads a datetime python object from a JSON string
 
         Args:
@@ -32,7 +32,7 @@ class DateTime(Field):
 
         return datetime.strptime(value, self._format)
 
-    def dump(self, value, mapper):
+    def _dump(self, value, mapper):
         """Dump a datetime to string representation
 
         Args:

--- a/lupin/fields/field.py
+++ b/lupin/fields/field.py
@@ -73,6 +73,22 @@ class Field(object):
 
     def load(self, value, mapper):
         """Loads python object from JSON value
+            using pre_load and post_load
+        Args:
+            value (object): a value
+            mapper (Mapper): mapper used to load data
+
+        Returns:
+            object
+        """
+
+        value = self.pre_load(value)
+        value = self._load(value, mapper)
+        value = self.post_load(value)
+        return value
+
+    def _load(self, value, mapper):
+        """Loads python object from JSON value
 
         Args:
             value (object): a value
@@ -84,6 +100,21 @@ class Field(object):
         return value
 
     def dump(self, value, mapper):
+        """Dump value to its JSON representation
+           using pre_dump and post_dump
+            Args:
+                value (object): a value
+                mapper (Mapper): mapper used to dump data
+
+            Returns:
+                object
+        """
+        value = self._pre_dump(value)
+        value = self._dump(value, mapper)
+        value = self._post_dump(value)
+        return value
+
+    def _dump(self, value, mapper):
         """Dump value to its JSON representation
 
         Args:
@@ -110,9 +141,7 @@ class Field(object):
         """
         key = self.binding or key
         raw_value = getattr(obj, key)
-        value = self._pre_dump(raw_value)
-        value = self.dump(value, mapper)
-        return self._post_dump(value)
+        return self.dump(raw_value, mapper)
 
     def validate(self, value, path, mapper):
         """Validate value againt field validators

--- a/lupin/fields/list.py
+++ b/lupin/fields/list.py
@@ -17,7 +17,7 @@ class List(Field):
         super(List, self).__init__(**kwargs)
         self._field = field
 
-    def load(self, value, mapper):
+    def _load(self, value, mapper):
         """Loads list of python objects from JSON list
 
         Args:
@@ -30,9 +30,10 @@ class List(Field):
         if value is None:
             return None
 
-        return [self._field.load(item, mapper) for item in value]
+        return [self._field.load(item, mapper)
+                for item in value]
 
-    def dump(self, value, mapper):
+    def _dump(self, value, mapper):
         """Dump list of object
 
         Args:
@@ -45,7 +46,8 @@ class List(Field):
         if value is None:
             return None
 
-        return [self._field.dump(item, mapper) for item in value]
+        return [self._field.dump(item, mapper)
+                for item in value]
 
     def validate(self, value, path, mapper):
         """Validate each items of list against nested field validators.

--- a/lupin/fields/object.py
+++ b/lupin/fields/object.py
@@ -18,7 +18,7 @@ class Object(Field):
         super(Object, self).__init__(*args, **kwargs)
         self._schema = schema
 
-    def load(self, value, mapper):
+    def _load(self, value, mapper):
         """Loads python object from JSON object
 
         Args:
@@ -33,7 +33,7 @@ class Object(Field):
 
         return mapper.load(value, self._schema)
 
-    def dump(self, value, mapper):
+    def _dump(self, value, mapper):
         """Dump object into its JSON representation
 
         Args:

--- a/lupin/fields/polymorphic_list.py
+++ b/lupin/fields/polymorphic_list.py
@@ -31,7 +31,7 @@ class PolymorphicList(Field):
         self._schemas_by_json_value = schemas
         self._schemas = list(schemas.values())
 
-    def load(self, value, mapper):
+    def _load(self, value, mapper):
         """Loads list of python objects from JSON list
 
         Args:
@@ -48,7 +48,7 @@ class PolymorphicList(Field):
                 for item
                 in value]
 
-    def dump(self, value, mapper):
+    def _dump(self, value, mapper):
         """Dump list of object
 
         Args:

--- a/lupin/fields/polymorphic_object.py
+++ b/lupin/fields/polymorphic_object.py
@@ -30,7 +30,7 @@ class PolymorphicObject(Field):
         self._schemas_by_json_value = schemas
         self._schemas = list(schemas.values())
 
-    def load(self, value, mapper):
+    def _load(self, value, mapper):
         """Loads python objects from JSON object
 
         Args:
@@ -46,7 +46,7 @@ class PolymorphicObject(Field):
         schema = self._schemas_by_json_value[value.get(self._on, self._default_type)]
         return mapper.load(value, schema)
 
-    def dump(self, value, mapper):
+    def _dump(self, value, mapper):
         """Dump object
 
         Args:

--- a/lupin/schema.py
+++ b/lupin/schema.py
@@ -87,9 +87,7 @@ class Schema(object):
                 continue
             if key in data:
                 raw_value = data[key]
-                value = field.pre_load(raw_value)
-                value = field.load(value, mapper)
-                value = field.post_load(value)
+                value = field.load(raw_value, mapper)
             elif allow_partial:
                 continue
             else:

--- a/tests/lupin/fields/test_field.py
+++ b/tests/lupin/fields/test_field.py
@@ -18,12 +18,12 @@ def field():
 
 class TestDump(object):
     def test_returns_the_same_value(self, field, mapper):
-        assert field.dump("46", mapper) == "46"
+        assert field._dump("46", mapper) == "46"
 
 
 class TestLoad(object):
     def test_returns_the_same_value(self, field, mapper):
-        assert field.load("46", mapper) == "46"
+        assert field._load("46", mapper) == "46"
 
 
 class TestPreLoad(object):
@@ -34,6 +34,16 @@ class TestPreLoad(object):
 class TestPostLoad(object):
     def test_use_default_processor(self, field):
         assert field.post_load("hello") == "hello"
+
+
+class TestFullLoad(object):
+    def test_use_pre_and_post_load(self, field, mapper):
+        assert field.load("hello", mapper) == "HELLO"
+
+
+class TestFullDump(object):
+    def test_use_pre_and_post_dump(self, field, mapper):
+        assert field.dump("  LUPIN ", mapper) == "lupin"
 
 
 class TestExtractAttr(object):


### PR DESCRIPTION
…se of list that was not calling pre_load, post_load

The list.load() was calling directly field.load() without calls to pre_load ans post_load. The other fild, like PolymorphicList goes througt the mapper, so the pre_load and post_load were called. 

I propose to call pre_load and post_load in the load() method, and move the previous load() as a method to override in the other class inheriting field, since calling load() without pre_load and post_load is not used. 

